### PR TITLE
feature: 4-add-validations

### DIFF
--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.js
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.js
@@ -2,7 +2,46 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Sponsoring', {
-	// refresh: function(frm) {
+	onload: function(frm) {
+		if(frm.is_new()){
+			// Get today's date
+			const today = frappe.datetime.get_today();
+			const today_date = new Date(today);
+			const year = today_date.getFullYear();
 
-	// }
+			// Set the next 1st July
+			const next_july = new Date(year, 6, 1);
+			if (today_date > next_july) {
+				next_july.setFullYear(year + 1);
+			}
+			frm.set_value('contract_start', next_july);
+		}
+	},
+
+	contract_start: function(frm) {
+		const contract_start_year = new Date(frm.doc.contract_start).getFullYear();
+
+		// Set contract end date to 30th June of the next year
+		const contract_end = new Date(contract_start_year + 1, 5, 30);
+		frm.set_value('contract_end', contract_end);
+
+		// Set the end of December
+		const latest_notice_date = new Date(contract_start_year, 11, 31);
+		frm.set_value('latest_notice_date', latest_notice_date);
+	},
+	
+	net_total: function(frm) {
+		// Set grand total
+		frappe.call({
+            method: 'ssv_reutlingen.ssv_reutlingen.doctype.sponsoring.sponsoring.calculate_grand_total',
+            args: {
+                net_total: frm.doc.net_total
+            },
+            callback: function(res) {
+                if (res.message) {
+                    frm.set_value('grand_total', res.message);
+                }
+            }
+        });
+	}
 });

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.py
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.py
@@ -1,8 +1,15 @@
 # Copyright (c) 2024, phamos.eu and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 class Sponsoring(Document):
 	pass
+
+@frappe.whitelist()
+def calculate_grand_total(net_total):
+	settings = frappe.get_single("SSV Reutlingen Settings")
+	tax_rate = settings.tax_rate or 0
+	grand_total = float(net_total) * (1 + tax_rate / 100)
+	return grand_total


### PR DESCRIPTION
Task: [#18](https://git.phamos.eu/ssv-reutlingen/ssv-reutlingen/-/work_items/18)
- When we open a new Sponsoring document, the following value automatically calculated based on the fiscal year.
  - `contract start date`
  - `contract end date`
  - `latest notice date`
- The `contract end date` and `latest notice date` will be automatically calculated whenever the `contract start date` changes.
- The `grand total` will be calcualted automatically (based on the net amount value) when the `net amount` is set.

![ssv](https://github.com/user-attachments/assets/290861b4-0a9b-49e1-9c27-3882c1937a55)
