### PR TITLE
feature: 4-sponsoring-doctype

### DIFF
--- a/ssv_reutlingen/ssv_reutlingen/doctype/contribution_type/contribution_type.json
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/contribution_type/contribution_type.json
@@ -1,0 +1,38 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-09-25 10:11:22.193006",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "type",
+  "amount"
+ ],
+ "fields": [
+  {
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Type",
+   "options": "Barter\nCash"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2024-09-25 10:11:22.193006",
+ "modified_by": "Administrator",
+ "module": "SSV Reutlingen",
+ "name": "Contribution Type",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/ssv_reutlingen/ssv_reutlingen/doctype/contribution_type/contribution_type.py
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/contribution_type/contribution_type.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2024, phamos.eu and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class ContributionType(Document):
+	pass

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.js
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.js
@@ -45,3 +45,39 @@ frappe.ui.form.on('Sponsoring', {
         });
 	}
 });
+
+frappe.ui.form.on('Sponsoring Items', {
+	net_rate: function(frm,cdt,cdn) {
+		let row = locals[cdt][cdn];
+		row.net_amount = calculate_amount(row.net_rate, row.quantity)
+		refresh_field("net_amount", cdn, "sponsoring_items");
+		calculate_net_total(frm)
+	},
+
+	quantity: function(frm,cdt,cdn) {
+		let row = locals[cdt][cdn];
+		row.net_amount = calculate_amount(row.net_rate, row.quantity)
+		refresh_field("net_amount", cdn, "sponsoring_items");
+		calculate_net_total(frm)
+	},
+
+	sponsoring_items_remove: function(frm,cdt,cdn){
+		calculate_net_total(frm)
+	}
+});
+
+function calculate_amount (net_rate, quantity) {
+	return net_rate * quantity
+}
+
+function calculate_net_total (frm) {
+	frappe.call({
+		method: 'calculate_net_total',
+		doc: frm.doc,
+		callback: function(res) {
+			if (res.message) {
+				frm.set_value('net_total', res.message);
+			}
+		}
+	});
+}

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.json
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.json
@@ -15,14 +15,17 @@
   "sponsoring_category",
   "latest_notice_date",
   "upload_notice",
-  "net_total",
-  "grand_total",
   "contract_url",
-  "type",
   "column_break_ddcos",
   "notes",
   "sponsoring_items_section",
-  "sponsoring_items"
+  "sponsoring_items",
+  "section_break_vmeaz",
+  "net_total",
+  "column_break_s1gab",
+  "grand_total",
+  "section_break_jsjo4",
+  "contribution_type"
  ],
  "fields": [
   {
@@ -79,16 +82,20 @@
    "label": "Upload Notice"
   },
   {
+   "default": "0",
    "description": "Input field for net total of contract for the above start/end",
    "fieldname": "net_total",
    "fieldtype": "Currency",
-   "label": "Net Total"
+   "label": "Net Total",
+   "read_only": 1
   },
   {
+   "default": "0",
    "description": "Input field for grand total of contract for the above start/end. Net Total + Tax",
    "fieldname": "grand_total",
    "fieldtype": "Currency",
-   "label": "Grand Total"
+   "label": "Grand Total",
+   "read_only": 1
   },
   {
    "description": "Here the URL to nextcloud can be pasted to have a shortcut to the original contract",
@@ -96,12 +103,6 @@
    "fieldtype": "Data",
    "label": "Contract URL",
    "options": "URL"
-  },
-  {
-   "description": "Barter or Cash?",
-   "fieldname": "type",
-   "fieldtype": "Data",
-   "label": "Type"
   },
   {
    "fieldname": "column_break_ddcos",
@@ -124,11 +125,29 @@
    "fieldtype": "Table",
    "label": "Sponsoring Items",
    "options": "Sponsoring Items"
+  },
+  {
+   "fieldname": "column_break_s1gab",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_vmeaz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_jsjo4",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "contribution_type",
+   "fieldtype": "Table",
+   "label": "Contribution Type",
+   "options": "Contribution Type"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-03 15:18:13.129747",
+ "modified": "2024-09-25 17:14:18.607644",
  "modified_by": "Administrator",
  "module": "SSV Reutlingen",
  "name": "Sponsoring",

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.py
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.py
@@ -3,9 +3,26 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe import _
 
 class Sponsoring(Document):
-	pass
+	def validate(self):
+		self.validate_contribution_type()
+
+	def validate_contribution_type(self):
+		total_contribution_amount = 0
+		for ct in self.contribution_type:
+			total_contribution_amount += ct.amount
+		
+		if total_contribution_amount != self.net_total:
+			frappe.throw(_("The sum of Contribution Type amounts must equal with Net Total"))
+
+	@frappe.whitelist()
+	def calculate_net_total(self):
+		total_net_amount = 0
+		for item in self.sponsoring_items:
+			total_net_amount += item.net_amount
+		return total_net_amount
 
 @frappe.whitelist()
 def calculate_grand_total(net_total):

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring_items/sponsoring_items.json
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring_items/sponsoring_items.json
@@ -18,7 +18,9 @@
   "column_break_sitcc",
   "todo",
   "delivery_status",
-  "delivery_note"
+  "delivery_note",
+  "email_template",
+  "email_body"
  ],
  "fields": [
   {
@@ -45,18 +47,19 @@
    "fetch_from": "item_code.description",
    "fieldname": "item_description",
    "fieldtype": "Text Editor",
-   "in_list_view": 1,
    "label": "Item Description",
    "print_width": "400",
    "width": "400"
   },
   {
+   "default": "0",
    "fieldname": "net_rate",
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Net Rate"
   },
   {
+   "default": "0",
    "fieldname": "quantity",
    "fieldtype": "Float",
    "in_list_view": 1,
@@ -65,7 +68,6 @@
   {
    "fieldname": "uom",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "UOM",
    "options": "UOM"
   },
@@ -101,12 +103,25 @@
    "fieldname": "delivery_note",
    "fieldtype": "Text",
    "label": "Delivery Note"
+  },
+  {
+   "fieldname": "email_template",
+   "fieldtype": "Link",
+   "label": "Email Template",
+   "options": "Email Template"
+  },
+  {
+   "fetch_from": "email_template.response",
+   "fetch_if_empty": 1,
+   "fieldname": "email_body",
+   "fieldtype": "Text Editor",
+   "label": "Email Body "
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-04 13:52:24.436709",
+ "modified": "2024-09-25 17:25:47.507593",
  "modified_by": "Administrator",
  "module": "SSV Reutlingen",
  "name": "Sponsoring Items",

--- a/ssv_reutlingen/translations/de.csv
+++ b/ssv_reutlingen/translations/de.csv
@@ -20,3 +20,4 @@ Barter or Cash?,Tauschhandel oder Bargeld?
 Sponsoring Items,Sponsoring-Artikel
 Commercials,Werbespots
 SSV Reutlingen Settings,SSV Reutlingen Einstellungen
+The sum of Contribution Type amounts must equal with Net Total,Die Summe der Beitragsartenbeträge muss dem Nettogesamtbetrag entsprechen


### PR DESCRIPTION
Task: [#22](https://git.phamos.eu/ssv-reutlingen/ssv-reutlingen/-/work_items/22)

- Reorder `Net Total` and `Grand Total` fields to the bottom of `Sponsoring Items` child table.
- `Net Total` on Sponsoring doctype is the sum of `Net Amounts` from `Sponsoring Items` child table.
![reorder](https://github.com/user-attachments/assets/fa0af688-4294-4573-bfdc-6baa6d560b8a)

Task: [#21](https://git.phamos.eu/ssv-reutlingen/ssv-reutlingen/-/work_items/21)

- `Contribution Type` cihld table added with `Barter` and `Cash` as a preset value.
- Validation made to match the sum of `Barter` and `Cash` to much against the `Net Total` amount.  

![contribution_type_validation](https://github.com/user-attachments/assets/4e60b9ac-b01f-42a7-a34a-ba16b84d1b67)

