### PR TITLE
fix/28-customer-group-translation

### DIFF
--- a/ssv_reutlingen/ssv_reutlingen/report/customer_details/customer_details.py
+++ b/ssv_reutlingen/ssv_reutlingen/report/customer_details/customer_details.py
@@ -22,7 +22,7 @@ def get_columns():
 			"label": _("Customer Group"),
 			"fieldname": "customer_group",
 			"fieldtype": "Link",
-			"options": _("Customer Group"),
+			"options": "Customer Group",
 			"width": 150
 		},
         {


### PR DESCRIPTION
- Removed the translation from the Customer Group Link field which caused "Customer Group Not Found" error.