### PR TITLE
feature/37-add-link-in-doctypes

### DIFF
--- a/ssv_reutlingen/dashboard/customer_dashboard_extension.py
+++ b/ssv_reutlingen/dashboard/customer_dashboard_extension.py
@@ -1,0 +1,12 @@
+from frappe import _
+
+def get_data(data):
+    
+    custom_section = {
+        "label": _("Sponsoring"),
+        "items": ["Sponsoring"]
+    }
+
+    data.get("transactions", []).append(custom_section)
+
+    return data

--- a/ssv_reutlingen/hooks.py
+++ b/ssv_reutlingen/hooks.py
@@ -146,9 +146,9 @@ before_uninstall = "ssv_reutlingen.setup.install.before_uninstall"
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,
 # along with any modifications made in other Frappe apps
-# override_doctype_dashboards = {
-#	"Task": "ssv_reutlingen.task.get_dashboard_data"
-# }
+override_doctype_dashboards = {
+	"Customer": "ssv_reutlingen.dashboard.customer_dashboard_extension.get_data"
+}
 
 # exempt linked doctypes from being automatically cancelled
 #


### PR DESCRIPTION
- Task: [#37](https://git.phamos.eu/ssv-reutlingen/ssv-reutlingen/-/work_items/37)
- Added a custom linked document called `Sponsoring` on the connection section for `Customer` doctype.

![Screenshot from 2025-01-15 18-30-26 – ScreenClip](https://github.com/user-attachments/assets/3e4061b2-3d41-44e1-b775-0fa1c2551dc8)
