### PR TITLE
fix/29-automatically-fetch-email-templates

### DIFF
--- a/ssv_reutlingen/public/js/sales_order_button.js
+++ b/ssv_reutlingen/public/js/sales_order_button.js
@@ -30,6 +30,18 @@ frappe.ui.form.on('Sales Order', {
                                     options: "Email Template",
                                     in_list_view: 1,
                                 },
+                                {
+                                    fieldtype: "Data",
+                                    fieldname: "subject",
+                                    label: __("Subject"),
+                                    fetch_from: "email_template.subject",
+                                },
+                                {
+                                    fieldtype: "Text Editor",
+                                    fieldname: "response",
+                                    label: __("Response"),
+                                    fetch_from: "email_template.response",
+                                },
                             ],
                             data: frm.doc.items.map(item => ({
                                 item_code: item.item_code,

--- a/ssv_reutlingen/setup/install.py
+++ b/ssv_reutlingen/setup/install.py
@@ -53,43 +53,7 @@ def get_custom_fields():
         },
 	]
 
-	custom_fields_sales_order_item = [
-		{
-			"label": "SSV Reutlingen",
-			"fieldname": "ssv_reutlingen",
-			"fieldtype": "Section Break",
-		},
-        {
-			"label": "Email Template",
-            "fieldname": "email_template",
-            "fieldtype": "Link",
-			"options": "Email Template",
-			"fetch_from": "item_code.email_template",
-			"insert_after": "ssv_reutlingen"
-        },
-		{
-			"label": "Subject",
-            "fieldname": "subject",
-            "fieldtype": "Data",
-			"fetch_from": "email_template.subject",
-			"insert_after": "email_template"
-        },
-		{
-			"label": "Response",
-            "fieldname": "response",
-            "fieldtype": "Text Editor",
-			"fetch_from": "email_template.response",
-			"insert_after": "subject"
-        },
-		{
-			"fieldname": "ssv_last_section",
-			"fieldtype": "Section Break",
-			"insert_after": "response"
-		},
-	]
-
 	return {
 		"Sales Order": custom_fields_sales_order,
 		"Item": custom_fields_item,
-		"Sales Order Item": custom_fields_sales_order_item
 	}

--- a/ssv_reutlingen/setup/install.py
+++ b/ssv_reutlingen/setup/install.py
@@ -36,13 +36,24 @@ def get_custom_fields():
 			"allow_on_submit": 1,
             "insert_after": "ssv_section"
         },
+	]
+
+	custom_fields_item = [
 		{
-			"fieldname": "ssv_last_section",
+			"label": "SSV Reutlingen",
+			"fieldname": "ssv_reutlingen",
 			"fieldtype": "Section Break",
-			"insert_after": "processed"
-		}
+		},
+        {
+			"label": "Email Template",
+            "fieldname": "email_template",
+            "fieldtype": "Link",
+			"options": "Email Template",
+            "insert_after": "ssv_reutlingen"
+        },
 	]
 
 	return {
-		"Sales Order": custom_fields_sales_order
+		"Sales Order": custom_fields_sales_order,
+		"Item": custom_fields_item
 	}

--- a/ssv_reutlingen/setup/install.py
+++ b/ssv_reutlingen/setup/install.py
@@ -53,7 +53,43 @@ def get_custom_fields():
         },
 	]
 
+	custom_fields_sales_order_item = [
+		{
+			"label": "SSV Reutlingen",
+			"fieldname": "ssv_reutlingen",
+			"fieldtype": "Section Break",
+		},
+        {
+			"label": "Email Template",
+            "fieldname": "email_template",
+            "fieldtype": "Link",
+			"options": "Email Template",
+			"fetch_from": "item_code.email_template",
+			"insert_after": "ssv_reutlingen"
+        },
+		{
+			"label": "Subject",
+            "fieldname": "subject",
+            "fieldtype": "Data",
+			"fetch_from": "email_template.subject",
+			"insert_after": "email_template"
+        },
+		{
+			"label": "Response",
+            "fieldname": "response",
+            "fieldtype": "Text Editor",
+			"fetch_from": "email_template.response",
+			"insert_after": "subject"
+        },
+		{
+			"fieldname": "ssv_last_section",
+			"fieldtype": "Section Break",
+			"insert_after": "response"
+		},
+	]
+
 	return {
 		"Sales Order": custom_fields_sales_order,
-		"Item": custom_fields_item
+		"Item": custom_fields_item,
+		"Sales Order Item": custom_fields_sales_order_item
 	}


### PR DESCRIPTION
- Task: [#39](https://git.phamos.eu/ssv-reutlingen/ssv-reutlingen/-/work_items/39)
- Created a section of Email Template on the `Item` doctype itself for mapping email template for each item.

![Screenshot from 2025-01-20 10-31-37](https://github.com/user-attachments/assets/32b3130e-6874-40be-aff2-a2b3a8079583)

- Task [#40](https://git.phamos.eu/ssv-reutlingen/ssv-reutlingen/-/work_items/40)
- When clicking on `Create Delivery Notes and Send Emails` custom button on `Sales Order` doctype, the assigned email template for each item including the subject and response will automatically appear on the dialog.
- Users can edit the email template content(subject/response) and then send the edited content as an email without overwriting the saved email template in the system.

![emailEdit](https://github.com/user-attachments/assets/940af2dc-c40c-43ef-8378-45936d868fb3)
