### PR TITLE
fix: change-status-to-bill

### DIFF
--- a/ssv_reutlingen/api/custom_sales_order.py
+++ b/ssv_reutlingen/api/custom_sales_order.py
@@ -46,6 +46,9 @@ def create_delivery_notes(sales_order, dialog_data, items):
         send_csv_via_email(email, delivery_note_doc, template)
 
     sales_order_doc.db_set("processed", 1)
+    sales_order_doc.db_set("status", "To Bill")
+    sales_order_doc.db_set("delivery_status", "Fully Delivered")
+    sales_order_doc.db_set("per_delivered", 100)
 
     return {"message": "Delivery Notes created successfully!"}
 


### PR DESCRIPTION
- When creating Delivery Notes from Sales Order by clicking on `Create Delivery Notes and Send Emails` custom button, the status of the Sales Order will be changed to `To Bill`.