### PR TITLE
feature/42-delivery-note-automation-sponsoring-doctype

### DIFF
--- a/ssv_reutlingen/api/custom_delivery_note.py
+++ b/ssv_reutlingen/api/custom_delivery_note.py
@@ -33,7 +33,7 @@ def create_delivery_notes(doctype, name, dialog_data, items):
             "item_code": item.get('item_code'),
             "qty": item.get('qty'),
             "rate": item.get('rate') if doctype == "Sales Order" else item.get('net_rate'),
-            "warehouse": item.get('warehouse') if doctype == "Sales Order" else "Stores - P",
+            "warehouse": item.get('warehouse'),
             "uom": item.get('uom'),
         }
         

--- a/ssv_reutlingen/api/custom_sales_order.py
+++ b/ssv_reutlingen/api/custom_sales_order.py
@@ -3,9 +3,9 @@ import json
 from frappe import _
 
 @frappe.whitelist()
-def create_delivery_notes(sales_order, dialog_data, items):
+def create_delivery_notes(doctype, name, dialog_data, items):
 
-    sales_order_doc = frappe.get_doc("Sales Order", sales_order)
+    doc = frappe.get_doc(doctype, name)
     items = json.loads(items)
     dialog_data = json.loads(dialog_data)
     
@@ -22,18 +22,18 @@ def create_delivery_notes(sales_order, dialog_data, items):
         )
 
         delivery_note_doc = frappe.new_doc("Delivery Note")
-        delivery_note_doc.customer = sales_order_doc.customer
+        delivery_note_doc.customer = doc.customer
         delivery_note_doc.posting_date = frappe.utils.nowdate()
         delivery_note_doc.set("items", [])
-        email = sales_order_doc.contact_email
+        email = doc.contact_email
         template = next((it for it in dialog_data if it["item_code"] == item.get('item_code')), None)
 
 
         item_data = {
             "item_code": item.get('item_code'),
             "qty": item.get('qty'),
-            "rate": item.get('rate'),
-            "warehouse": item.get('warehouse'),
+            "rate": item.get('rate') if doctype == "Sales Order" else item.get('net_rate'),
+            "warehouse": item.get('warehouse') if doctype == "Sales Order" else "Stores - P",
             "uom": item.get('uom'),
         }
         
@@ -45,10 +45,11 @@ def create_delivery_notes(sales_order, dialog_data, items):
 
         send_csv_via_email(email, delivery_note_doc, template)
 
-    sales_order_doc.db_set("processed", 1)
-    sales_order_doc.db_set("status", "To Bill")
-    sales_order_doc.db_set("delivery_status", "Fully Delivered")
-    sales_order_doc.db_set("per_delivered", 100)
+    doc.db_set("processed", 1)
+    if doctype == "Sales Order":
+        doc.db_set("status", "To Bill")
+        doc.db_set("delivery_status", "Fully Delivered")
+        doc.db_set("per_delivered", 100)
 
     return {"message": "Delivery Notes created successfully!"}
 

--- a/ssv_reutlingen/public/js/sales_order_button.js
+++ b/ssv_reutlingen/public/js/sales_order_button.js
@@ -5,7 +5,8 @@ frappe.ui.form.on('Sales Order', {
             frm.doc.processed = 0
         }
         
-        const has_valid_items = frm.doc.items.some(item => item.item_code);
+        const has_valid_items = frm.doc.items ? frm.doc.items.some(item => item.item_code) : false;
+
         if (!frm.doc.processed && has_valid_items && frm.doc.docstatus === 1) {
             frm.add_custom_button(__('Create Delivery Notes and Send Emails'), async function() {
                 const emailTemplates = await fetchEmailTemplates();
@@ -97,7 +98,7 @@ frappe.ui.form.on('Sales Order', {
                         dialog.hide();
                         
                         frappe.call({
-                            method: "ssv_reutlingen.api.custom_sales_order.create_delivery_notes",
+                            method: "ssv_reutlingen.api.custom_delivery_note.create_delivery_notes",
                             args: {
                                 doctype: "Sales Order",
                                 name: frm.doc.name,
@@ -120,7 +121,7 @@ frappe.ui.form.on('Sales Order', {
                 const emailTemplates = [];
                 for (let item of frm.doc.items) {
                     const response = await frappe.call({
-                        method: "ssv_reutlingen.api.custom_sales_order.get_email_template",
+                        method: "ssv_reutlingen.api.custom_delivery_note.get_email_template",
                         args: {
                             item_code: item.item_code
                         }

--- a/ssv_reutlingen/public/js/sales_order_button.js
+++ b/ssv_reutlingen/public/js/sales_order_button.js
@@ -99,7 +99,8 @@ frappe.ui.form.on('Sales Order', {
                         frappe.call({
                             method: "ssv_reutlingen.api.custom_sales_order.create_delivery_notes",
                             args: {
-                                sales_order: frm.doc.name,
+                                doctype: "Sales Order",
+                                name: frm.doc.name,
                                 dialog_data: dialog_data,
                                 items: frm.doc.items
                             },

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.js
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.js
@@ -2,6 +2,147 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Sponsoring', {
+	refresh: function(frm) {
+		if (frm.is_new()) {
+            frm.set_value('processed', 0);
+        }
+
+		const has_valid_items = frm.doc.sponsoring_items.some(item => item.item_code);
+		if (!frm.doc.processed && has_valid_items) {
+			frm.add_custom_button(__('Create Delivery Notes and Send Emails'), async function() {
+                const emailTemplates = await fetchEmailTemplates();
+                const dialog = new frappe.ui.Dialog({
+                    title: __("Create Delivery Notes and Send Emails"),
+                    fields: [
+                        {
+                            fieldtype: "Table",
+                            fieldname: "items_with_templates",
+                            label: __("Items and Email Templates"),
+                            fields: [
+                                {
+                                    fieldtype: "Link",
+                                    fieldname: "item_code",
+                                    label: __("Item Code"),
+                                    options: 'Item',
+                                    in_list_view: 1,
+                                },
+                                {
+                                    fieldtype: "Link",
+                                    fieldname: "email_template",
+                                    label: __("Email Template"),
+                                    options: "Email Template",
+                                    in_list_view: 1,
+                                    onchange: function(){
+                
+                                        const data = dialog.fields_dict.items_with_templates.grid.df.get_data()
+                                        data.forEach(row => {
+                                            const emailTemplate =  row.email_template;
+                                            if (emailTemplate) {
+                                                frappe.call({
+                                                    method: "frappe.client.get",
+                                                    args: {
+                                                        doctype: "Email Template",
+                                                        name: emailTemplate,
+                                                    },
+                                                    callback: function (response) {
+                                                        if (response.message) {
+                                                            const template = response.message;
+                                                           
+                                                            dialog.fields_dict.items_with_templates.df.data.some((doc) => {
+                                                                if (doc.email_template == emailTemplate){
+                                                                    doc.subject = template.subject || ""
+                                                                    doc.response = template.response || ""
+                                                                }
+                                                        
+                                                            });
+
+                                                            dialog.fields_dict.items_with_templates.grid.refresh();
+                                                        }
+                                                    },
+                                                });
+                                            }
+                                        });
+                                    }
+                                },
+                                {
+                                    fieldtype: "Data",
+                                    fieldname: "subject",
+                                    label: __("Subject"),
+                                },
+                                {
+                                    fieldtype: "Text Editor",
+                                    fieldname: "response",
+                                    label: __("Response"),
+                                },
+                            ],
+                            data: frm.doc.sponsoring_items.map(item => ({
+                                item_code: item.item_code,
+                                email_template: emailTemplates.find(et => et.item_code === item.item_code)?.email_template || "",
+                                subject: emailTemplates.find(et => et.item_code === item.item_code)?.subject || "",
+                                response: emailTemplates.find(et => et.item_code === item.item_code)?.response || "", 
+                                edit_option: 0,
+                            })),
+                            get_data: () => {
+                                return dialog.get_value("items_with_templates");
+                            },
+                        },
+                    ],
+                    primary_action_label: __("Create Delivery Notes"),
+                    primary_action: function() {
+                        let dialog_data = dialog.get_value("items_with_templates");
+
+                        if (!dialog_data || !dialog_data.length) {
+                            frappe.msgprint(__("Please map at least one Email Template to proceed."));
+                            return;
+                        }
+                        
+                        dialog.hide();
+                        
+                        frappe.call({
+                            method: "ssv_reutlingen.api.custom_sales_order.create_delivery_notes",
+                            args: {
+                                doctype: "Sponsoring",
+                                name: frm.doc.name,
+                                dialog_data: dialog_data,
+                                items: frm.doc.sponsoring_items
+                            },
+                            callback: function(response) {
+                                if (response.message) {
+                                    frm.reload_doc();
+                                    frappe.msgprint(__("Delivery Notes created and emails sent successfully!"));
+                                }
+                            }
+                        });
+                    },
+                });
+                dialog.show();
+            });
+
+            async function fetchEmailTemplates() {
+                const emailTemplates = [];
+                for (let item of frm.doc.sponsoring_items) {
+                    const response = await frappe.call({
+                        method: "ssv_reutlingen.api.custom_sales_order.get_email_template",
+                        args: {
+                            item_code: item.item_code
+                        }
+                    });
+                    
+                    if (response.message && response.message.email_template) {
+                        emailTemplates.push({
+                            item_code: item.item_code,
+                            email_template: response.message.email_template,
+                            subject: response.message.subject,
+                            response: response.message.response
+                        });
+                    }
+                }
+           
+                return emailTemplates;
+            }
+		}
+	},
+
 	onload: function(frm) {
 		if(frm.is_new()){
 			// Get today's date
@@ -17,6 +158,23 @@ frappe.ui.form.on('Sponsoring', {
 			frm.set_value('contract_start', next_july);
 		}
 	},
+
+    customer: function(frm) {
+        frappe.call({
+            method: "frappe.client.get",
+            args: {
+                doctype: "Contact",
+                name: frm.doc.customer_primary_contact,
+            },
+            callback: function (response) {
+                if (response.message) {
+                    const contact = response.message;
+                    frm.set_value('contact_email', contact.email_id)   
+                }
+            },
+        });
+        
+    },
 
 	contract_start: function(frm) {
 		const contract_start_year = new Date(frm.doc.contract_start).getFullYear();
@@ -49,14 +207,14 @@ frappe.ui.form.on('Sponsoring', {
 frappe.ui.form.on('Sponsoring Items', {
 	net_rate: function(frm,cdt,cdn) {
 		let row = locals[cdt][cdn];
-		row.net_amount = calculate_amount(row.net_rate, row.quantity)
+		row.net_amount = calculate_amount(row.net_rate, row.qty)
 		refresh_field("net_amount", cdn, "sponsoring_items");
 		calculate_net_total(frm)
 	},
 
-	quantity: function(frm,cdt,cdn) {
+	qty: function(frm,cdt,cdn) {
 		let row = locals[cdt][cdn];
-		row.net_amount = calculate_amount(row.net_rate, row.quantity)
+		row.net_amount = calculate_amount(row.net_rate, row.qty)
 		refresh_field("net_amount", cdn, "sponsoring_items");
 		calculate_net_total(frm)
 	},
@@ -66,8 +224,8 @@ frappe.ui.form.on('Sponsoring Items', {
 	}
 });
 
-function calculate_amount (net_rate, quantity) {
-	return net_rate * quantity
+function calculate_amount (net_rate, qty) {
+	return net_rate * qty
 }
 
 function calculate_net_total (frm) {

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.json
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.json
@@ -9,9 +9,10 @@
  "field_order": [
   "customer",
   "customer_name",
+  "customer_primary_contact",
+  "contact_email",
   "contract_start",
   "contract_end",
-  "customer_contact",
   "sponsoring_category",
   "latest_notice_date",
   "upload_notice",
@@ -23,6 +24,7 @@
   "notification_before_days",
   "sponsoring_items_section",
   "sponsoring_items",
+  "processed",
   "section_break_vmeaz",
   "net_total",
   "column_break_s1gab",
@@ -57,13 +59,6 @@
    "fieldname": "contract_end",
    "fieldtype": "Date",
    "label": "Contract End"
-  },
-  {
-   "description": "Main Contact who is responsible for this Sponsoring/Contract on customer Side",
-   "fieldname": "customer_contact",
-   "fieldtype": "Link",
-   "label": "Customer Contact",
-   "options": "Contact"
   },
   {
    "description": "Link to which Sponsoring Category this customer is in",
@@ -164,11 +159,33 @@
    "fieldtype": "Select",
    "label": "Renew or Expire",
    "options": "Renew Automatically\nExpire Automatically"
+  },
+  {
+   "default": "0",
+   "fieldname": "processed",
+   "fieldtype": "Check",
+   "label": "Processed"
+  },
+  {
+   "fieldname": "contact_email",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Contact Email",
+   "options": "Email",
+   "read_only": 1
+  },
+  {
+   "description": "Main Contact who is responsible for this Sponsoring/Contract on customer Side",
+   "fetch_from": "customer.customer_primary_contact",
+   "fieldname": "customer_primary_contact",
+   "fieldtype": "Data",
+   "label": "Customer Primary Contact",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-03 15:35:12.993958",
+ "modified": "2025-02-14 12:07:29.420157",
  "modified_by": "Administrator",
  "module": "SSV Reutlingen",
  "name": "Sponsoring",

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.json
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.json
@@ -18,6 +18,7 @@
   "upload_notice",
   "contract_url",
   "column_break_ddcos",
+  "company",
   "notes",
   "renew_or_expire",
   "status",
@@ -38,7 +39,8 @@
    "fieldname": "customer",
    "fieldtype": "Link",
    "label": "Customer",
-   "options": "Customer"
+   "options": "Customer",
+   "reqd": 1
   },
   {
    "description": "Full name of linked Customer",
@@ -52,13 +54,15 @@
    "description": "Start Date of Contract",
    "fieldname": "contract_start",
    "fieldtype": "Date",
-   "label": "Contract Start"
+   "label": "Contract Start",
+   "reqd": 1
   },
   {
    "description": "End date of Contract",
    "fieldname": "contract_end",
    "fieldtype": "Date",
-   "label": "Contract End"
+   "label": "Contract End",
+   "reqd": 1
   },
   {
    "description": "Link to which Sponsoring Category this customer is in",
@@ -71,7 +75,8 @@
    "description": "Date to which the Customer can cancel the contract for it not be be continued",
    "fieldname": "latest_notice_date",
    "fieldtype": "Date",
-   "label": "Latest Notice Date"
+   "label": "Latest Notice Date",
+   "reqd": 1
   },
   {
    "description": "Here you can upload the PDF or other file with Notice from customer",
@@ -164,6 +169,7 @@
    "default": "0",
    "fieldname": "processed",
    "fieldtype": "Check",
+   "hidden": 1,
    "label": "Processed"
   },
   {
@@ -181,11 +187,20 @@
    "fieldtype": "Data",
    "label": "Customer Primary Contact",
    "read_only": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company",
+   "read_only": 1,
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-14 12:07:29.420157",
+ "modified": "2025-02-17 15:58:23.881926",
  "modified_by": "Administrator",
  "module": "SSV Reutlingen",
  "name": "Sponsoring",

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.py
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.py
@@ -46,6 +46,17 @@ def calculate_grand_total(net_total):
 
 
 @frappe.whitelist()
+def get_item_details(item_code, company):
+	item_defaults = frappe.db.get_value(
+		"Item Default",
+		{"parent": item_code, "company": company},
+		["default_warehouse"],
+	)
+	
+	return item_defaults
+
+
+@frappe.whitelist()
 def sponsoring_contract_auto_management():
 	"""Background job to update Sponsoring contract status for renewal or expiration."""
 

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring_items/sponsoring_items.json
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring_items/sponsoring_items.json
@@ -15,6 +15,7 @@
   "uom",
   "net_amount",
   "discount",
+  "warehouse",
   "column_break_sitcc",
   "todo",
   "delivery_status",
@@ -116,12 +117,17 @@
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Quantity"
+  },
+  {
+   "fieldname": "warehouse",
+   "fieldtype": "Data",
+   "label": "Warehouse"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-14 11:20:40.553555",
+ "modified": "2025-02-17 12:30:11.974393",
  "modified_by": "Administrator",
  "module": "SSV Reutlingen",
  "name": "Sponsoring Items",

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring_items/sponsoring_items.json
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring_items/sponsoring_items.json
@@ -11,7 +11,7 @@
   "item_name",
   "item_description",
   "net_rate",
-  "quantity",
+  "qty",
   "uom",
   "net_amount",
   "discount",
@@ -57,13 +57,6 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Net Rate"
-  },
-  {
-   "default": "0",
-   "fieldname": "quantity",
-   "fieldtype": "Float",
-   "in_list_view": 1,
-   "label": "Quantity"
   },
   {
    "fieldname": "uom",
@@ -116,12 +109,19 @@
    "fieldname": "email_body",
    "fieldtype": "Text Editor",
    "label": "Email Body "
+  },
+  {
+   "default": "0",
+   "fieldname": "qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Quantity"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-25 17:25:47.507593",
+ "modified": "2025-02-14 11:20:40.553555",
  "modified_by": "Administrator",
  "module": "SSV Reutlingen",
  "name": "Sponsoring Items",


### PR DESCRIPTION
- Task: [#42](https://git.phamos.eu/ssv-reutlingen/ssv-reutlingen/-/work_items/42)
- Automatically creates delivery note for each sponsoring item and then send email for each delivery note doc created when the `Create Delivery Note and Send Emails` custom button clicked.
- A Sponsoring document will only be processed once.
- Added custom field called processed which will be checked if all sponsoring items are created as a separate delivery note doc.

![delivery_note_creation](https://github.com/user-attachments/assets/b35f51e6-f28c-4dfc-8298-4a1fa9e300ff)
