### PR TITLE
feat/45-sponsoring-workflow

### DIFF
--- a/ssv_reutlingen/api/custom_quotation.py
+++ b/ssv_reutlingen/api/custom_quotation.py
@@ -1,0 +1,38 @@
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+def make_sponsoring(source_name, target_doc=None):
+    return _make_sponsoring(source_name, target_doc)
+
+
+def _make_sponsoring(source_name, target_doc=None):
+    def set_missing_values(source, target):
+        target.customer = source.party_name
+        target.company = source.company
+        target.quotation = source.name
+        target.prevdoc_docname = source.name
+
+    doc = get_mapped_doc("Quotation", source_name, {
+        "Quotation": {
+            "doctype": "Sponsoring",
+            "field_map": {
+                "party_name": "customer",
+                "company": "company",
+            }
+        },
+        "Quotation Item": {
+            "doctype": "Sponsoring Items",
+            "field_map": {
+                "item_code": "item_code",
+                "description": "item_description",
+                "uom": "uom",
+                "qty": "qty",
+                "rate": "net_rate",
+            }
+        }
+    }, target_doc, set_missing_values)
+    
+    frappe.db.set_value("Quotation", source_name, "sponsoring", doc.name)
+
+    return doc

--- a/ssv_reutlingen/dashboard/quotation_dashboard_extension.py
+++ b/ssv_reutlingen/dashboard/quotation_dashboard_extension.py
@@ -1,0 +1,12 @@
+from frappe import _
+
+def get_data(data):
+    
+    custom_section = {
+        "label": _("Sponsoring"),
+        "items": ["Sponsoring"]
+    }
+
+    data.get("transactions", []).append(custom_section)
+
+    return data

--- a/ssv_reutlingen/hooks.py
+++ b/ssv_reutlingen/hooks.py
@@ -33,6 +33,7 @@ app_license = "MIT"
 # include js in doctype views
 doctype_js = {
 	"Sales Order" : "public/js/sales_order_button.js",
+    "Quotation" : "public/js/quotation.js",
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
@@ -134,7 +135,8 @@ scheduler_events = {
 # along with any modifications made in other Frappe apps
 override_doctype_dashboards = {
 	"Customer": "ssv_reutlingen.dashboard.customer_dashboard_extension.get_data",
-	"Sales Order": "ssv_reutlingen.dashboard.sales_order_dashboard_extension.get_data"
+	"Sales Order": "ssv_reutlingen.dashboard.sales_order_dashboard_extension.get_data",
+    "Quotation": "ssv_reutlingen.dashboard.quotation_dashboard_extension.get_data"
 }
 
 # exempt linked doctypes from being automatically cancelled

--- a/ssv_reutlingen/public/js/quotation.js
+++ b/ssv_reutlingen/public/js/quotation.js
@@ -1,0 +1,37 @@
+frappe.ui.form.on('Quotation', {
+	refresh: function(frm) {
+        const has_valid_items = frm.doc.items ? frm.doc.items.some(item => item.item_code) : false;
+
+        if (!frm.doc.sponsoring) {
+            if (has_valid_items) {
+                frm.add_custom_button(
+                    __('Sponsoring'), 
+                    () => frm.events.make_sponsoring(frm),
+                    __('Create'));
+
+                // override the plus icon after sale order reference 
+                const button = document.querySelector('button.btn-secondary[data-doctype="Sponsoring"]');
+                if (button) {
+                    button.replaceWith(button.cloneNode(true));
+                    const newButton = document.querySelector('button.btn-secondary[data-doctype="Sponsoring"]');
+                    newButton.addEventListener('click',
+                        () => frm.events.make_sponsoring(frm)
+                    );
+                }
+            }
+        }
+        else {
+            const button = document.querySelector('button.btn-secondary[data-doctype="Sponsoring"]');
+            if (button) {
+                button.remove()
+            }
+        }
+	},
+
+    make_sponsoring: function(frm) {
+        frappe.model.open_mapped_doc({
+            method: 'ssv_reutlingen.api.custom_quotation.make_sponsoring',
+            frm: frm
+        });
+    },
+});

--- a/ssv_reutlingen/setup/install.py
+++ b/ssv_reutlingen/setup/install.py
@@ -1,6 +1,5 @@
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
-from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 
 def after_migrate():
 	create_custom_fields(get_custom_fields())
@@ -60,7 +59,24 @@ def get_custom_fields():
         },
 	]
 
+	custom_fields_quotation = [
+		{
+			"label": "SSV Reutlingen",
+			"fieldname": "ssv_reutlingen",
+			"fieldtype": "Section Break",
+			"hidden": 1
+		},
+		{
+			"fieldname": "sponsoring",
+            "fieldtype": "Link",
+			"options": "Sponsoring",
+			"label": "Sponsoring",
+            "insert_after": "ssv_reutlingen"
+		}
+	]
+
 	return {
 		"Sales Order": custom_fields_sales_order,
 		"Item": custom_fields_item,
+		"Quotation": custom_fields_quotation,
 	}

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.js
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.js
@@ -4,28 +4,25 @@
 frappe.ui.form.on('Sponsoring', {
 	refresh: function(frm) {
 		const has_valid_items = frm.doc.sponsoring_items ? frm.doc.sponsoring_items.some(item => item.item_code) : false;
-        
-		if (!frm.doc.sales_order) {
-            if (has_valid_items){
-                frm.add_custom_button(
-                    __('Sales Order'), 
-                    () => frm.events.make_sales_order(frm),
-                    __('Create'));
-                
-                // override the plus icon after sale order reference 
-                const button = document.querySelector('button.btn-secondary[data-doctype="Sales Order"]');
-                if (button) {
-                    button.replaceWith(button.cloneNode(true));
-                    const newButton = document.querySelector('button.btn-secondary[data-doctype="Sales Order"]');
-                    newButton.addEventListener('click',
-                        () => frm.events.make_sales_order(frm)
-                    );
-                }
-            }
-		} else {
+        const button = document.querySelector('button.btn-secondary[data-doctype="Quotation"]');
+        if (button) {
+            button.remove()
+        }
+
+        if (has_valid_items){
+            frm.add_custom_button(
+                __('Sales Order'), 
+                () => frm.events.make_sales_order(frm),
+                __('Create'));
+            
+            // override the plus icon after sale order reference 
             const button = document.querySelector('button.btn-secondary[data-doctype="Sales Order"]');
             if (button) {
-                button.remove()
+                button.replaceWith(button.cloneNode(true));
+                const newButton = document.querySelector('button.btn-secondary[data-doctype="Sales Order"]');
+                newButton.addEventListener('click',
+                    () => frm.events.make_sales_order(frm)
+                );
             }
         }
 	},

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.json
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.json
@@ -24,6 +24,8 @@
   "status",
   "sponsoring_items_section",
   "sponsoring_items",
+  "quotation",
+  "prevdoc_docname",
   "sales_order",
   "section_break_vmeaz",
   "net_total",
@@ -182,6 +184,18 @@
    "reqd": 1
   },
   {
+   "fieldname": "quotation",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Quotation",
+   "options": "Quotation"
+  },
+  {
+   "fieldname": "prevdoc_docname",
+   "fieldtype": "Data",
+   "label": "Prev Doc"
+  },
+  {
    "fieldname": "sales_order",
    "fieldtype": "Link",
    "hidden": 1,
@@ -191,7 +205,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-10 09:10:18.732063",
+ "modified": "2025-05-06 10:37:17.782666",
  "modified_by": "Administrator",
  "module": "SSV Reutlingen",
  "name": "Sponsoring",

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.py
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring.py
@@ -13,7 +13,11 @@ class Sponsoring(Document):
 		self.validate_contribution_type()
 		self.set_status()
 		self.remove_sales_order()
-		
+	
+	def on_update(self):
+		if self.quotation:
+			frappe.db.set_value("Quotation", self.quotation, "sponsoring", self.name)
+
 	def remove_sales_order(self):
 		if self.is_new():
 			self.sales_order = None
@@ -92,7 +96,6 @@ def create_sales_order(source_name, target_doc=None):
 			"field_map": {
 				"customer": "customer",
 				"company": "company",
-				
 			}
 		},
 		"Sponsoring Items": {

--- a/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring_dashboard.py
+++ b/ssv_reutlingen/ssv_reutlingen/doctype/sponsoring/sponsoring_dashboard.py
@@ -7,5 +7,6 @@ def get_data():
 		
 		"transactions": [
 			{"label": _("Sales Order"), "items": ["Sales Order"]},
+			{"label": _("Quotation"), "items": ["Quotation"]},
 		],
 	}


### PR DESCRIPTION
- Task: https://git.phamos.eu/ssv-reutlingen/ssv-reutlingen/-/issues/45
- Implemented logic to create Sponsoring from Quotation, with all relevant item and sponsor data copied over.
- Enabled creation of multiple Sales Order from Sponsoring, transferring item and detail information seamlessly.
- Linked Sponsoring document to the Customer, with visibility on the Customer Dashboard under "Connections".
- Ensured all document relations (Quotation → Sponsoring → Sales Order → Delivery Note) are properly linked and traceable.
- Tested linkage integrity and traceability across the workflow chain.

![sponsoring-workflow](https://github.com/user-attachments/assets/e624bf0b-13ee-42de-a276-8d9f03928e39)
